### PR TITLE
Changed install_plugins() to allow remote installation without local plugins

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,9 @@ Revision history for {{$dist->name}}
 
 {{$NEXT}}
 
+3.09      2014-03-22 22:19:00 Pacific/Los_Angeles
+        - changed install_plugins() to allow remote installation without local plugins
+
 3.08      2012-10-06 12:02:29 Pacific/Auckland
         - changed install_to_host() method to no longer die on error
 

--- a/bin/bcvi
+++ b/bin/bcvi
@@ -950,7 +950,7 @@ sub install_bcvi_script {
 sub install_plugins {
     my($self, $host) = @_;
 
-    return unless @installables;
+    return 1 unless @installables;
     if(system("ssh $host test -d ./.config/bcvi") != 0) {
         print "Creating plugins directory on $host\n";
         if( system("ssh $host mkdir -p ./.config/bcvi") != 0 ) {


### PR DESCRIPTION
Line 953 in install_plugins() previously returned 0 if there were no local plugins to remotely install. In 3.07, this had no effect, but in 3.08 this causes the chain of functions performing the remote installation to fail prematurely without remotely installing aliases. 

Since bcvi can operate without plugins, this patch allows users without local bcvi plugins to perform remote installations.
